### PR TITLE
Add 'sendPlayOnce' optional configuration property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ var player = new Clappr.Player({
 
 `readyCallback` property is an optional callback function called when eStat library is ready.
 
+`sendPlayOnce` property is an optional boolean which indicate if "play" events triggered as the result of "buffer full" during playback are __not__ send to eStat. Default value is `false`. (all "play" events are send).
+
 This plugin also add `estatNewSession` method to Clappr player instance. This optional method may be used for live stream to create a new session when program change or for load another video source without destroying player or changing options.
 
 ```javascript

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,8 @@
             level5: '',
             genre: 'Heroic fantasy',
           },
-          readyCallback: function() { console.log('eStat plugin is ready !') }
+          readyCallback: function() { console.log('eStat plugin is ready !') },
+          // sendPlayOnce: true,
         },
       })
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,10 @@ export default class EstatPlugin extends CorePlugin {
       throw new Error(this.name + ' plugin "readyCallback" configuration property is not a function')
     }
 
+    // sendPlayOnce parameter is optional
+    this._playOnce = this.options.estatPlugin.sendPlayOnce === true
+    this._doSendPlay = true
+
     this.eStatSetup()
   }
 
@@ -43,6 +47,7 @@ export default class EstatPlugin extends CorePlugin {
       this.listenTo(this._container, Events.CONTAINER_PLAY, this.onPlay)
       this.listenTo(this._container, Events.CONTAINER_STOP, this.onStop)
       this.listenTo(this._container, Events.CONTAINER_PAUSE, this.onPause)
+      this.listenTo(this._container, Events.CONTAINER_SEEK, this.onSeek)
     }
   }
 
@@ -191,14 +196,24 @@ export default class EstatPlugin extends CorePlugin {
   }
 
   onPlay() {
+    if (this._playOnce) {
+      if (!this._doSendPlay) return
+      this._doSendPlay = false
+    }
     window.eStat_ms && window.eStat_ms.TagDS(this.playerElement).sendEvent(window.eStatPlayState.Play)
   }
 
   onStop() {
     window.eStat_ms && window.eStat_ms.TagDS(this.playerElement).sendEvent(window.eStatPlayState.Stop)
+    if (this._playOnce) this._doSendPlay = true
   }
 
   onPause() {
     window.eStat_ms && window.eStat_ms.TagDS(this.playerElement).sendEvent(window.eStatPlayState.Pause)
+    if (this._playOnce) this._doSendPlay = true
+  }
+
+  onSeek() {
+    if (this._playOnce) this._doSendPlay = true
   }
 }


### PR DESCRIPTION
"play" event is trigger most of the cases after a "buffer full" event as the result either autoplay, user click play button or user clicked on seek bar.

But "play" event is also trigger after buffer full during playback (slow connection, etc...) resulting in sending additional "play" events.

If this option is set to `true`, the "play" event is send only once after video is started, or after a seek. If video pause or stop, then play, the "play" event is send again.
