### PR TITLE
Ensure tag polling is stopped before destroy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Therefore, the minimal required plugin configuration is :
 
 This version use browser console to display informations. _(alert if eStatTag is not properly configured, and more...)_
 
-This property is only for development purposes. Do not set to `true` in production.
+This property is only for development purposes. Do NOT set to `true` in production.
 
 ## secure
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,6 +1,7 @@
 <head>
   <script type="text/javascript" src="http://cdn.clappr.io/latest/clappr.js"></script>
-  <script type="text/javascript" src="../dist/clappr-estat-plugin.min.js"></script>
+  <!-- <script type="text/javascript" src="../dist/clappr-estat-plugin.min.js"></script> -->
+  <script type="text/javascript" src="../dist/clappr-estat-plugin.js"></script>
 </head>
 <body>
   <div id="player"></div>


### PR DESCRIPTION
Properly recall play, stop and pause event to decide if stop must be notified to tag on destroy.

Also add tag notify console messages is debug is enabled.
